### PR TITLE
chore: Rename err_threshold to error_threshold. Remove unused parameter. #1837

### DIFF
--- a/docs/configuration/flags.md
+++ b/docs/configuration/flags.md
@@ -43,7 +43,7 @@ Optional parameter setting the timeout duration, in milliseconds, for commits.
 Optional parameter indicating the buffer capacity, in bytes, for the Log Writer.  
 **Type**: Integer | **Default**: `1073741824`  
 
-#### `err_threshold`
+#### `error_threshold`
 Optional setting determining the error threshold. Exceeding this number would terminate the process.
 **Type**: Integer | **Default**: `0`  
 


### PR DESCRIPTION
doc-update: chore: Rename err_threshold to error_threshold. Remove unused parameter. #1837 [https://github.com/getdozer/dozer/pull/1837](url)
Needs review: @chubei 